### PR TITLE
add playwright tests to enable cross-browser testing

### DIFF
--- a/ext/wasm/playwright/.gitignore
+++ b/ext/wasm/playwright/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/ext/wasm/playwright/package-lock.json
+++ b/ext/wasm/playwright/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "playwright",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.29.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
+      "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.29.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
+    },
+    "node_modules/playwright-core": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
+      "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  },
+  "dependencies": {
+    "@playwright/test": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
+      "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.29.1"
+      }
+    },
+    "@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
+    },
+    "playwright-core": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
+      "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
+      "dev": true
+    }
+  }
+}

--- a/ext/wasm/playwright/package.json
+++ b/ext/wasm/playwright/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "playwright",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.29.1"
+  }
+}

--- a/ext/wasm/playwright/playwright.config.js
+++ b/ext/wasm/playwright/playwright.config.js
@@ -1,0 +1,109 @@
+// @ts-check
+const { devices } = require('@playwright/test');
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ * @type {import('@playwright/test').PlaywrightTestConfig}
+ */
+const config = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+module.exports = config;

--- a/ext/wasm/playwright/tests/sqlite-loads.spec.js
+++ b/ext/wasm/playwright/tests/sqlite-loads.spec.js
@@ -1,0 +1,11 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test('sqlite loads', async ({ page }) => {
+  page.on('pageerror', (error) => {
+    throw error;
+  });
+
+  await page.goto('http://localhost:8080/demo-123.html');
+  await page.getByText(`That's all, folks!`).waitFor({timeout: 10000});
+});


### PR DESCRIPTION
This runs `demo-123.html` in:
- webkit
- firefox
- chrome

on whatever platform you may be on (Linux, Windows, Mac).

To install and run:
```
cd ext/wasm/playwright
npm install
npm test
```

---

Example output:

<img width="823" alt="Screenshot 2023-01-02 at 2 29 41 PM" src="https://user-images.githubusercontent.com/1009003/210272113-0951400a-6649-41de-9fac-20b9900c336e.png">

<img width="1001" alt="Screenshot 2023-01-02 at 2 29 35 PM" src="https://user-images.githubusercontent.com/1009003/210272127-d49c8781-fcb7-4e23-bc4f-9b00bbc89e08.png">

<img width="990" alt="Screenshot 2023-01-02 at 2 32 48 PM" src="https://user-images.githubusercontent.com/1009003/210272222-67c1e817-a8bc-4a1d-adc8-9d6aed68fb3f.png">


