### PR TITLE
Fix macos compiler-warning "comparison of integers of different signs"

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -1708,7 +1708,7 @@ char sqlite3AffinityType(const char *zIn, Column *pCol){
       }
     }
 #ifdef SQLITE_ENABLE_SORTER_REFERENCES
-    if( v>=sqlite3GlobalConfig.szSorterRef ){
+    if( (u32)v>=sqlite3GlobalConfig.szSorterRef ){
       pCol->colFlags |= COLFLAG_SORTERREF;
     }
 #endif


### PR DESCRIPTION
this fixes a compiler warning in macos in [this build-log](https://github.com/kaizhu256/sqlmath/actions/runs/4360485093/jobs/7623436151#step:9:76)

```
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  CC(target) Release/obj.target/sqlite3_c/../sqlite3.o
../../sqlite3.c:130725:10: warning: comparison of integers of different signs: 'int' and 'u32' (aka 'unsigned int') [-Wsign-compare]
    if( v>=sqlite3GlobalConfig.szSorterRef ){
        ~^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```