### PR TITLE
Fix common misspelling in English dictionary

### DIFF
--- a/doc/testrunner.md
+++ b/doc/testrunner.md
@@ -133,7 +133,7 @@ If there is no permutation, the individual test script may be run with:
   ./testfixture $PATH_TO_SCRIPT
 ```
 
-Or, if the failure occured as part of a permutation:
+Or, if the failure occurred as part of a permutation:
 
 ```
   ./testfixture $TESTDIR/testrunner.tcl $PERMUTATION $PATH_TO_SCRIPT

--- a/ext/fts5/fts5_test_mi.c
+++ b/ext/fts5/fts5_test_mi.c
@@ -387,7 +387,7 @@ static void fts5MatchinfoFunc(
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(pCtx, rc);
   }else{
-    /* No errors has occured, so return a copy of the array of integers. */
+    /* No errors has occurred, so return a copy of the array of integers. */
     int nByte = p->nRet * sizeof(u32);
     sqlite3_result_blob(pCtx, (void*)p->aRet, nByte, SQLITE_TRANSIENT);
   }

--- a/ext/lsm1/lsm-test/lsmtest5.c
+++ b/ext/lsm1/lsm-test/lsmtest5.c
@@ -557,7 +557,7 @@ static void mt1Main(ThreadSet *pThreadSet, int iThread, void *pCtx){
   }
   testClose(&pDb);
 
-  /* If an error has occured, set the thread error code and the threadset 
+  /* If an error has occurred, set the thread error code and the threadset 
   ** halt flag to tell the other test threads to halt. Otherwise, set the
   ** thread error code to 0 and post a message with the number of read
   ** and write operations completed.  */

--- a/ext/lsm1/lsm_main.c
+++ b/ext/lsm1/lsm_main.c
@@ -771,7 +771,7 @@ int lsm_csr_open(lsm_db *pDb, lsm_cursor **ppCsr){
     rc = lsmMCursorNew(pDb, &pCsr);
   }
 
-  /* If an error has occured, set the output to NULL and delete any partially
+  /* If an error has occurred, set the output to NULL and delete any partially
   ** allocated cursor. If this means there are no open cursors, release the
   ** client snapshot.  */
   if( rc!=LSM_OK ){

--- a/ext/lsm1/lsm_shared.c
+++ b/ext/lsm1/lsm_shared.c
@@ -1981,7 +1981,7 @@ int lsm_checkpoint(lsm_db *pDb, int *pnKB){
   rc = lsmCheckpointWrite(pDb, &nWrite);
 
   /* If required, calculate the output variable (KB of data checkpointed). 
-  ** Set it to zero if an error occured.  */
+  ** Set it to zero if an error occurred.  */
   if( pnKB ){
     int nKB = 0;
     if( rc==LSM_OK && nWrite ){

--- a/ext/session/sqlite3session.c
+++ b/ext/session/sqlite3session.c
@@ -4371,7 +4371,7 @@ static int sessionBindRow(
 ** iterator pIter points to to the SELECT and attempts to seek to the table
 ** entry. If a row is found, the SELECT statement left pointing at the row 
 ** and SQLITE_ROW is returned. Otherwise, if no row is found and no error
-** has occured, the statement is reset and SQLITE_OK is returned. If an
+** has occurred, the statement is reset and SQLITE_OK is returned. If an
 ** error occurs, the statement is reset and an SQLite error code is returned.
 **
 ** If this function returns SQLITE_ROW, the caller must eventually reset() 


### PR DESCRIPTION
Corrected one of the frequently misspelled words in the English dictionary to ensure accuracy and clarity for users.

Reference:

- https://writer.com/blog/occurred-occured/
- https://www.grammarly.com/blog/occurred-occured-ocurred/