### PR TITLE
Update sqlite3session.c 处理一个可能的 "const" 警告

### DIFF
--- a/ext/session/sqlite3session.c
+++ b/ext/session/sqlite3session.c
@@ -1223,7 +1223,7 @@ static int sessionInitTable(
   if( pTab->nCol==0 ){
     u8 *abPK;
     assert( pTab->azCol==0 || pTab->abPK==0 );
-    sqlite3_free(pTab->azCol);
+    sqlite3_free((void *)pTab->azCol);
     pTab->abPK = 0;
     rc = sessionTableInfo(pSession, db, zDb, 
         pTab->zName, &pTab->nCol, &pTab->nTotalCol, 0, &pTab->azCol, 


### PR DESCRIPTION
我在 VS 2008 中编译会有这个警告。
sqlite3.c(232150): warning C4090: “函数”: 不同的“const”限定符