### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/ext/fts5/fts5_index.c
+++ b/ext/fts5/fts5_index.c
@@ -6311,9 +6311,9 @@ static void fts5MergePrefixLists(
 ** all index terms corresponding to pToken/nToken are collapsed into a single
 ** term before the callback is invoked.
 **
-** The callback invoked for each entry visited is specified by paramter xVisit.
+** The callback invoked for each entry visited is specified by parameter xVisit.
 ** Each time it is invoked, it is passed a pointer to the Fts5Index object,
-** a copy of the 7th paramter to this function (pCtx) and a pointer to the
+** a copy of the 7th parameter to this function (pCtx) and a pointer to the
 ** iterator that indicates the current entry. If the current entry is the
 ** first with a new term (i.e. different from that of the previous entry,
 ** including the very first term), then the final two parameters are passed

--- a/ext/intck/sqlite3intck.h
+++ b/ext/intck/sqlite3intck.h
@@ -44,7 +44,7 @@
 **   }
 **   rc = sqlite3_intck_error(p, &zErr);
 **   if( rc!=SQLITE_OK ){
-**     printf("error occured (rc=%d), (errmsg=%s)\n", rc, zErr);
+**     printf("error occurred (rc=%d), (errmsg=%s)\n", rc, zErr);
 **   }
 **   sqlite3_intck_close(p);
 **

--- a/ext/rbu/sqlite3rbu.c
+++ b/ext/rbu/sqlite3rbu.c
@@ -1807,7 +1807,7 @@ static char *rbuObjIterGetIndexCols(
 
 /*
 ** Assuming the current table columns are "a", "b" and "c", and the zObj
-** paramter is passed "old", return a string of the form:
+** parameter is passed "old", return a string of the form:
 **
 **     "old.a, old.b, old.b"
 **


### PR DESCRIPTION

**Repo:** sqlite/sqlite (⭐ 6000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
Fix three minor typos in code comments across the FTS5, intck, and RBU
extensions: "paramter" → "parameter" (twice in fts5_index.c, once in
sqlite3rbu.c) and "occured" → "occurred" in the public sqlite3intck.h
header's example.

## Why
These are pure-comment typos visible to anyone reading the source or the
public sqlite3intck.h header. The intck change in particular fixes the
spelling in example code shown in the public-API doc-comment. Zero
behavior change, zero ABI/API risk.

## Testing
Comments-only changes — no test required. `git diff` confirms each hunk
edits only `**` comment lines; no functional code is altered.

## Risk
Low — comments only, no code paths affected.
