### PR TITLE
Disable the use of intrinsic high-precision multiplies on riscv32

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -472,7 +472,8 @@ u8 sqlite3StrIHash(const char *z){
 */
 static u64 sqlite3Multiply128(u64 a, u64 b, u64 *pLo){
 #if (defined(__GNUC__) || defined(__clang__)) \
-        && (defined(__x86_64__) || defined(__aarch64__) || defined(__riscv)) \
+        && (defined(__x86_64__) || defined(__aarch64__) \
+            || (defined(__riscv) && (__riscv_xlen == 64))) \
         && !defined(SQLITE_DISABLE_INTRINSIC)
   __uint128_t r = (__uint128_t)a * b;
   *pLo = (u64)r;
@@ -508,7 +509,8 @@ static u64 sqlite3Multiply128(u64 a, u64 b, u64 *pLo){
 */
 static u64 sqlite3Multiply160(u64 a, u32 aLo, u64 b, u32 *pLo){
 #if (defined(__GNUC__) || defined(__clang__)) \
-        && (defined(__x86_64__) || defined(__aarch64__) || defined(__riscv)) \
+        && (defined(__x86_64__) || defined(__aarch64__) \
+            || (defined(__riscv) && (__riscv_xlen == 64))) \
         && !defined(SQLITE_DISABLE_INTRINSIC)
   __uint128_t r = (__uint128_t)a * b;
   r += ((__uint128_t)aLo * b) >> 32;


### PR DESCRIPTION
Build is broken in riscv32:
```
/home/vincent/autobuild/instance-3/output-1/build/sqlite-3.53.0/sqlite3.c:
 In function 'sqlite3Multiply128':
/home/vincent/autobuild/instance-3/output-1/build/sqlite-3.53.0/sqlite3.c:36804:3:
 error: unknown type name '__uint128_t'; did you mean '__uint32_t'?
36804 |   __uint128_t r = (__uint128_t)a * b;
```
as reported by the buildroot autobuilders:
https://autobuild.buildroot.net/results/a6e/a6e4f391081c8059d93fb5b7bd33e08c57b27dcf//build-end.log

For a discussion about the preprocessor definitions see: https://github.com/riscv-android-src/platform-bionic/issues/10

Quoting some defines from the buildroot compiler that reported the build error:
```
$ echo | output/per-package/sqlite/host/bin/riscv32-buildroot-linux-gnu-gcc -dM -E - | grep "riscv \|xlen"
#define __riscv 1
#define __riscv_xlen 32
```