### PR TITLE
fix wrong UNC path detection

### DIFF
--- a/src/os_win.c
+++ b/src/os_win.c
@@ -3258,9 +3258,17 @@ int sqlite3_win_test_unc_locking = 0;
 /*
 ** Return true if the string passed as the only argument is likely
 ** to be a UNC path. In other words, if it starts with "\\".
+** A local DOS-device drive path ("\\?\X:\...") also starts with "\\",
+** but is not a UNC path.
 */
 static int winIsUNCPath(const char *zFile){
   if( zFile[0]=='\\' && zFile[1]=='\\' ){
+    if( winIsLongPathPrefix(zFile)
+     && winIsDriveLetterAndColon(zFile+4)
+     && winIsDirSep(zFile[6])
+    ){
+      return sqlite3_win_test_unc_locking;
+    }
     return 1;
   }
   return sqlite3_win_test_unc_locking;


### PR DESCRIPTION
Hi! I am a Software Engineer at Mozilla. We recently witnessed performance [regression ](https://bugzilla.mozilla.org/show_bug.cgi?id=2016438)after SQLite upgrade.

After investigating, we realized that our CI uses paths like these: ("\\?\X:\..."), which is [DOS ](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats) path, not UNC.
Which leads to using wrong mutex and therefore, performance decrease.

Here is the [perf test result](https://perf.compare/compare-results?baseRepo=try&baseRev=fe1d48c8072384153718ab4b0e50d146196060de&newRepo=try&newRev=7067af78d616dd7e5408291b6e7d3003b931c998&framework=13&replicates=true&test_version=mann-whitney-u) of this [patch ](https://phabricator.services.mozilla.com/D305558)and I am open to provide any assistance.

