### PR TITLE
Modernize hash table lookup: NULL instead of static sentinel

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -22,10 +22,7 @@
 */
 void sqlite3HashInit(Hash *pNew){
   assert( pNew!=0 );
-  pNew->first = 0;
-  pNew->count = 0;
-  pNew->htsize = 0;
-  pNew->ht = 0;
+  memset(pNew, 0, sizeof(*pNew));
 }
 
 /* Remove all entries from a hash table.  Reclaim all memory.
@@ -121,7 +118,7 @@ static int rehash(Hash *pH, unsigned int new_size){
   if( new_size==pH->htsize ) return 0;
 #endif
 
-  /* The inability to allocates space for a larger hash table is
+  /* The inability to allocate space for a larger hash table is
   ** a performance hit but it is not a fatal error.  So mark the
   ** allocation as a benign. Use sqlite3Malloc()/memset(0) instead of 
   ** sqlite3MallocZero() to make the allocation, as sqlite3MallocZero()
@@ -145,10 +142,10 @@ static int rehash(Hash *pH, unsigned int new_size){
   return 1;
 }
 
-/* This function (for internal use only) locates an element in an
-** hash table that matches the given key.  If no element is found,
-** a pointer to a static null element with HashElem.data==0 is returned.
-** If pH is not NULL, then the hash for this key is written to *pH.
+/* This function (for internal use only) locates an element in a
+** hash table that matches the given key.  Return a pointer to the
+** element, or NULL if no element is found.  If pHash is not NULL,
+** then the hash for this key is written to *pHash.
 */
 static HashElem *findElementWithHash(
   const Hash *pH,     /* The pH to be searched */
@@ -158,7 +155,6 @@ static HashElem *findElementWithHash(
   HashElem *elem;                /* Used to loop thru the element list */
   unsigned int count;            /* Number of elements left to test */
   unsigned int h;                /* The computed hash */
-  static HashElem nullElement = { 0, 0, 0, 0, 0 };
 
   h = strHash(pKey);
   if( pH->ht ){   /*OPTIMIZATION-IF-TRUE*/
@@ -179,7 +175,7 @@ static HashElem *findElementWithHash(
     elem = elem->next;
     count--;
   }
-  return &nullElement;
+  return 0;
 }
 
 /* Remove a single entry from the hash table given a pointer to that
@@ -220,9 +216,11 @@ static void removeElement(
 ** found, or NULL if there is no match.
 */
 void *sqlite3HashFind(const Hash *pH, const char *pKey){
+  HashElem *elem;
   assert( pH!=0 );
   assert( pKey!=0 );
-  return findElementWithHash(pH, pKey, 0)->data;
+  elem = findElementWithHash(pH, pKey, 0);
+  return elem ? elem->data : 0;
 }
 
 /* Insert an element into the hash table pH.  The key is pKey
@@ -247,7 +245,7 @@ void *sqlite3HashInsert(Hash *pH, const char *pKey, void *data){
   assert( pH!=0 );
   assert( pKey!=0 );
   elem = findElementWithHash(pH,pKey,&h);
-  if( elem->data ){
+  if( elem ){
     void *old_data = elem->data;
     if( data==0 ){
       removeElement(pH,elem);


### PR DESCRIPTION
## Summary
- Change `findElementWithHash()` to return `NULL` when no key matches, instead of a pointer to a static zeroed `HashElem` sentinel.
- Call sites (`sqlite3HashFind` / `sqlite3HashInsert`) check for a non-NULL element explicitly.
- Initialize `Hash` via `memset()` in `sqlite3HashInit()` so future structure fields cannot be left uninitialized.
- Minor comment grammar fix in the rehash path.

This is behavior-preserving for all existing callers; it only removes an internal pattern that is harder to reason about under modern C conventions (mutable static used as a read-only sentinel).

## Test plan
- [x] `./configure --dev && make sqlite3` in `build/`
- [x] CLI smoke test: create table, insert, select against `:memory:`
- [ ] `make devtest` / `testfixture` (Tcl on this host is x86_64-only; arm64 link fails without a full Rosetta rebuild)

Note: SQLite prefers Fossil and public-domain paperwork for upstream merges; this PR is offered as a focused proof-of-concept for review.