### PR TITLE
Fix inaccurate and misspelled comments in core and extensions

### DIFF
--- a/doc/testrunner.md
+++ b/doc/testrunner.md
@@ -230,7 +230,7 @@ If there is no permutation, the individual test script may be run with:
   ./testfixture $PATH_TO_SCRIPT
 ```
 
-Or, if the failure occured as part of a permutation:
+Or, if the failure occurred as part of a permutation:
 
 ```
   test/testrunner.tcl $PERMUTATION $PATH_TO_SCRIPT

--- a/ext/fts5/fts5_index.c
+++ b/ext/fts5/fts5_index.c
@@ -4694,7 +4694,7 @@ static void fts5TrimSegments(Fts5Index *p, Fts5Iter *pIter){
     if( pSeg->pSeg==0 ){
       /* no-op */
     }else if( pSeg->pLeaf==0 ){
-      /* All keys from this input segment have been transfered to the output.
+      /* All keys from this input segment have been transferred to the output.
       ** Set both the first and last page-numbers to 0 to indicate that the
       ** segment is now empty. */
       pSeg->pSeg->pgnoLast = 0;

--- a/ext/fts5/fts5_test_mi.c
+++ b/ext/fts5/fts5_test_mi.c
@@ -387,7 +387,7 @@ static void fts5MatchinfoFunc(
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(pCtx, rc);
   }else{
-    /* No errors has occured, so return a copy of the array of integers. */
+    /* No errors have occurred, so return a copy of the array of integers. */
     int nByte = p->nRet * sizeof(u32);
     sqlite3_result_blob(pCtx, (void*)p->aRet, nByte, SQLITE_TRANSIENT);
   }

--- a/ext/fts5/fts5_vocab.c
+++ b/ext/fts5/fts5_vocab.c
@@ -63,7 +63,7 @@ struct Fts5VocabCursor {
   void *pStruct;                  /* From sqlite3Fts5StructureRef() */
 
   int nLeTerm;                    /* Size of zLeTerm in bytes */
-  char *zLeTerm;                  /* (term <= $zLeTerm) paramater, or NULL */
+  char *zLeTerm;                  /* (term <= $zLeTerm) parameter, or NULL */
   int colUsed;                    /* Copy of sqlite3_index_info.colUsed */
 
   /* These are used by 'col' tables only */

--- a/ext/intck/sqlite3intck.h
+++ b/ext/intck/sqlite3intck.h
@@ -44,7 +44,7 @@
 **   }
 **   rc = sqlite3_intck_error(p, &zErr);
 **   if( rc!=SQLITE_OK ){
-**     printf("error occured (rc=%d), (errmsg=%s)\n", rc, zErr);
+**     printf("error occurred (rc=%d), (errmsg=%s)\n", rc, zErr);
 **   }
 **   sqlite3_intck_close(p);
 **

--- a/ext/qrf/README.md
+++ b/ext/qrf/README.md
@@ -8,7 +8,7 @@ table formats, with flexible column widths and alignments, row-oriented
 formats, such as CSV and similar, as well as various special purpose formats
 like JSON.
 
-For the first 25 years of SQLite's existance, the
+For the first 25 years of SQLite's existence, the
 [command-line interface](https://sqlite.org/cli.html) (CLI)
 formatted query results using a hodge-podge of routines
 that had grown slowly by accretion.  The QRF was created

--- a/ext/recover/sqlite3recover.c
+++ b/ext/recover/sqlite3recover.c
@@ -70,7 +70,7 @@ typedef struct RecoverColumn RecoverColumn;
 **   the bind parameter its values will be bound to in the INSERT statement
 **   used to construct the output database. If the table does has a rowid
 **   but not an INTEGER PRIMARY KEY column, then iRowidBind contains the
-**   index of the bind paramater to which the rowid value should be bound.
+**   index of the bind parameter to which the rowid value should be bound.
 **   Otherwise, it contains -1. If the table does contain an INTEGER PRIMARY 
 **   KEY column, then the rowid value should be bound to the index associated
 **   with the column.

--- a/ext/session/sqlite3session.c
+++ b/ext/session/sqlite3session.c
@@ -4723,7 +4723,7 @@ static int sessionBindValue(
 **
 ** New.* value $i from the iterator is bound to variable ($i+1) of 
 ** statement pStmt. If parameter abPK is NULL, all values from 0 to (nCol-1)
-** are transfered to the statement. Otherwise, if abPK is not NULL, it points
+** are transferred to the statement. Otherwise, if abPK is not NULL, it points
 ** to an array nCol elements in size. In this case only those values for 
 ** which abPK[$i] is true are read from the iterator and bound to the 
 ** statement.
@@ -4768,7 +4768,7 @@ static int sessionBindRow(
 ** iterator pIter points to to the SELECT and attempts to seek to the table
 ** entry. If a row is found, the SELECT statement left pointing at the row 
 ** and SQLITE_ROW is returned. Otherwise, if no row is found and no error
-** has occured, the statement is reset and SQLITE_OK is returned. If an
+** has occurred, the statement is reset and SQLITE_OK is returned. If an
 ** error occurs, the statement is reset and an SQLite error code is returned.
 **
 ** If this function returns SQLITE_ROW, the caller must eventually reset() 

--- a/ext/wasm/jaccwabyt/jaccwabyt.md
+++ b/ext/wasm/jaccwabyt/jaccwabyt.md
@@ -522,7 +522,7 @@ StructBinder has the following members:
   Allocates a new UTF-8-encoded, NUL-terminated copy of the given JS
   string and returns its address relative to `config.heap()`. If
   allocation returns 0 this function throws. Ownership of the memory
-  is transfered to the caller, who must eventually pass it to the
+  is transferred to the caller, who must eventually pass it to the
   configured `config.dealloc()` function.
 
 - `config`  
@@ -969,7 +969,7 @@ const x = new MyStruct({
 - If `wrap` is set then (A) it must be at least
   `MyStruct.structInfo.sizeof` of memory owned by the caller, (B) it
   _must_ have been allocated using the same allocator as Jaccwabyt is
-  configured for, and (C) ownership of it is transfered to the new
+  configured for, and (C) ownership of it is transferred to the new
   object. `zeroOnDispose` and `extraBytes` are disregarded if `wrap`
   is set. A falsy `wrap` value is equivalent to not providing one and
   a non-integer value, or a number less than 0, triggers an error.

--- a/src/complete.c
+++ b/src/complete.c
@@ -9,7 +9,7 @@
 **    May you share freely, never taking more than you give.
 **
 *************************************************************************
-** An tokenizer for SQL
+** A tokenizer for SQL
 **
 ** This file contains C code that implements the sqlite3_complete() API.
 ** This code used to be part of the tokenizer.c source file.  But by
@@ -51,12 +51,12 @@ extern const char sqlite3IsEbcdicIdChar[];
 /*
 ** Return zero if the given SQL string is complete - if all comments,
 ** string and blob literals, and quoted identifiers have been closed and
-** if the entire string ends with ";" and possible with ";END;" if the
+** if the entire string ends with ";" and possibly with ";END;" if the
 ** string is a CREATE TRIGGER statement.  A non-zero return indicates
 ** that the string is incomplete.  Bits of the return value indicate
 ** what is missing and is needed to close out the statement.
 **
-** Special handling is require for CREATE TRIGGER statements.
+** Special handling is required for CREATE TRIGGER statements.
 ** Whenever the CREATE TRIGGER keywords are seen, the statement
 ** must end with ";END;".
 **
@@ -81,15 +81,15 @@ extern const char sqlite3IsEbcdicIdChar[];
 **
 **   xx == '\''            Incomplete string or blob literal
 **   xx == '"'             Incomplete quoted identifier
-**   xx == '`'             Incompelte MySQL-style quoted identifier
-**   xx == ']'             Incomplete SQLServer-style quoted identifer
+**   xx == '`'             Incomplete MySQL-style quoted identifier
+**   xx == ']'             Incomplete SQLServer-style quoted identifier
 **   xx == '-'             Incomplete SQL-style comment
 **   xx == '/'             Incomplete C-style comment
 **   xx != 0               New values of xx may be added in the future
 **
 **   wwwwwwww              Interpret as a signed integer, the number
 **                         of unmatched "(".  Negative means there are
-**                         more ")" and "(".
+**                         more ")" than "(".
 **
 **   ((R>>24)&0xff)!=0     New uses for the 4th byte may be added
 **                         in the future
@@ -138,7 +138,7 @@ extern const char sqlite3IsEbcdicIdChar[];
 **
 ** If we compile with SQLITE_OMIT_TRIGGER, all of the computation needed
 ** to recognize the end of a trigger can be omitted.  All we have to do
-** is look for a semicolon that is not part of an string or comment.
+** is look for a semicolon that is not part of a string or comment.
 */
 sqlite3_int64 sqlite3_incomplete(const char *zSql){
   u8 state = 0;   /* Current state, using numbers defined in header comment */

--- a/src/fault.c
+++ b/src/fault.c
@@ -67,9 +67,10 @@ void sqlite3BenignMallocHooks(
 }
 
 /*
-** This (sqlite3EndBenignMalloc()) is called by SQLite code to indicate that
-** subsequent malloc failures are benign. A call to sqlite3EndBenignMalloc()
-** indicates that subsequent malloc failures are non-benign.
+** sqlite3BeginBenignMalloc() is called by SQLite code to indicate that
+** subsequent malloc failures are benign.  A later call to
+** sqlite3EndBenignMalloc() indicates that subsequent malloc failures are
+** again non-benign.
 */
 void sqlite3BeginBenignMalloc(void){
   wsdHooksInit;

--- a/src/main.c
+++ b/src/main.c
@@ -2263,7 +2263,7 @@ int sqlite3_overload_function(
 ** Register a trace function.  The pArg from the previously registered trace
 ** is returned. 
 **
-** A NULL trace function means that no tracing is executes.  A non-NULL
+** A NULL trace function means that no tracing is executed.  A non-NULL
 ** trace is a pointer to a function that is invoked at the start of each
 ** SQL statement.
 */
@@ -2315,7 +2315,7 @@ int sqlite3_trace_v2(
 ** Register a profile function.  The pArg from the previously registered
 ** profile function is returned. 
 **
-** A NULL profile function means that no profiling is executes.  A non-NULL
+** A NULL profile function means that no profiling is executed.  A non-NULL
 ** profile is a pointer to a function that is invoked at the conclusion of
 ** each SQL statement that is run.
 */

--- a/src/rowset.c
+++ b/src/rowset.c
@@ -47,7 +47,7 @@
 ** The initial batch number is zero, so if the very first TEST contains
 ** a non-zero batch number, it will see all prior INSERTs.
 **
-** No INSERTs may occurs after a SMALLEST.  An assertion will fail if
+** No INSERTs may occur after a SMALLEST.  An assertion will fail if
 ** that is attempted.
 **
 ** The cost of an INSERT is roughly constant.  (Sometimes new memory

--- a/src/sqlite.h.in
+++ b/src/sqlite.h.in
@@ -8901,7 +8901,7 @@ void sqlite3_result_str(sqlite3_context*, sqlite3_str*, int);
 ** to [sqlite3_result_str(C,S,F)].
 */
 #define SQLITE_COPY   0   /* Results copied.  Dynamic string unchanged */
-#define SQLITE_XFER   1   /* Results transfered.  Dynamic string reset */
+#define SQLITE_XFER   1   /* Results transferred.  Dynamic string reset */
 #define SQLITE_FINISH 2   /* Like SQLITE_XFER, plus dynamic string freed */
 
 /*

--- a/src/tclsqlite.c
+++ b/src/tclsqlite.c
@@ -44,7 +44,7 @@
 #   define SQLITE_TCLAPI
 # endif
 #endif
-/* Compatability between Tcl8.6 and Tcl9.0 */
+/* Compatibility between Tcl8.6 and Tcl9.0 */
 #if TCL_MAJOR_VERSION==9
 # define CONST const
 #elif !defined(Tcl_Size)

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -9,7 +9,7 @@
 **    May you share freely, never taking more than you give.
 **
 *************************************************************************
-** An tokenizer for SQL
+** A tokenizer for SQL
 **
 ** This file contains C code that splits an SQL input string up into
 ** individual tokens and sends those tokens one-by-one over to the


### PR DESCRIPTION
## Summary
- Correct the swapped `sqlite3BeginBenignMalloc` / `sqlite3EndBenignMalloc` documentation in `src/fault.c` (the old header named the wrong function).
- Fix grammar and spelling in the `sqlite3_incomplete()` API comment block in `src/complete.c`.
- Fix \"is executes\" → \"is executed\" in trace/profile docs in `src/main.c`.
- Correct common typos elsewhere (`parameter`, `transferred`, `occurred`, `compatibility`, `existence`, etc.) in core, FTS5, session, recover, intck, docs.

Comment-only; no runtime behavior change.

## Test plan
- [x] Rebuild `sqlite3` after changes
- [x] No functional code paths modified (comments/docs only)

Offered as a focused documentation cleanup PR for easier review.